### PR TITLE
Fix default config object

### DIFF
--- a/src/utils/plugin-with-default-config.js
+++ b/src/utils/plugin-with-default-config.js
@@ -3,5 +3,5 @@ const plugin = require('tailwindcss/plugin');
 const defaultConfig = require('../default-config');
 
 module.exports = function pluginWithDefaultConfig(pluginFn) {
-  return plugin(pluginFn, { gutenberg: defaultConfig });
+  return plugin(pluginFn, { theme: { gutenberg: defaultConfig } });
 };


### PR DESCRIPTION
To use theme(), all `gutenberg` settings should be in `{ theme: { gutenberg: { /* settings */ } }`. Therefor the [default config object given to `plugin()` should be a child of `theme`](https://tailwindcss.com/docs/plugins/#providing-default-options).